### PR TITLE
Use globs to find files

### DIFF
--- a/OvercrowdinTests/AddCommandTests.cs
+++ b/OvercrowdinTests/AddCommandTests.cs
@@ -22,7 +22,7 @@ namespace OvercrowdinTests
 		public async void AddCommandWithCommandLine()
 		{
 			var mockFileSystem = new MockFileSystem();
-			const string inputFileName = "test.json";
+			const string inputFileName = "test.txt";
 			const string apiKeyEnvVar = "KEYEXISTS";
 			const string projectId = "testcrowdinproject";
 			Environment.SetEnvironmentVariable(apiKeyEnvVar, "fakecrowdinapikey");
@@ -43,20 +43,19 @@ namespace OvercrowdinTests
 		public async void AddCommandWithConfigFile()
 		{
 			var mockFileSystem = new MockFileSystem();
-			const string inputFileName = "test.json";
+			const string inputFileName = "test.txt";
 			const string apiKeyEnvVar = "KEYEXISTS";
 			const string projectId = "testcrowdinproject";
 			Environment.SetEnvironmentVariable(apiKeyEnvVar, "fakecrowdinapikey");
-			mockFileSystem.File.WriteAllText("test.json", "{ mock: config }");
+			mockFileSystem.File.WriteAllText(inputFileName, "mock contents");
 			dynamic configJson = new JObject();
 
 			configJson.project_id = projectId;
 			configJson.api_key_env = apiKeyEnvVar;
 			configJson.base_path = ".";
 			dynamic file = new JObject();
-			file.source = "test.json";
-			var files = new JArray();
-			files.Add(file);
+			file.source = inputFileName;
+			var files = new JArray {file};
 			configJson.files = files;
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))

--- a/OvercrowdinTests/CommandUtilitiesTests.cs
+++ b/OvercrowdinTests/CommandUtilitiesTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using Overcrowdin;
+using Xunit;
+
+namespace OvercrowdinTests
+{
+	public class CommandUtilitiesTests : CrowdinApiTestBase
+	{
+		private static MockFileSystem SetUpDirectoryStructure()
+		{
+			var fileSys = new MockFileSystem();
+			fileSys.Directory.CreateDirectory("jane/doe");
+			fileSys.Directory.CreateDirectory("john/doe");
+			fileSys.Directory.CreateDirectory("john/quincy/adams");
+			fileSys.Directory.CreateDirectory("john/quincy/doe");
+			fileSys.File.WriteAllText("test.txt", "contents");
+			fileSys.File.WriteAllText("jane/test.txt", "contents");
+			fileSys.File.WriteAllText("jane/doe/test.txt", "contents");
+			fileSys.File.WriteAllText("jane/doe/test.txt", "contents");
+			fileSys.File.WriteAllText("john/test.txt", "contents");
+			fileSys.File.WriteAllText("john/doe/test.txt", "contents");
+			fileSys.File.WriteAllText("john/quincy/test.txt", "contents");
+			fileSys.File.WriteAllText("john/quincy/adams/test.txt", "contents");
+			fileSys.File.WriteAllText("john/quincy/adams/allonym.txt", "contents");
+			fileSys.File.WriteAllText("john/quincy/doe/test.txt", "contents");
+			return fileSys;
+		}
+
+		private static JObject SetUpConfig(string fileSourceGlob, string basePath = ".")
+		{
+			dynamic configJson = new JObject();
+
+			configJson.project_id = "testcrowdinproject";
+			configJson.api_key_env = "KEYEXISTS";
+			configJson.base_path = basePath;
+			dynamic file = new JObject();
+			file.source = fileSourceGlob;
+			var files = new JArray {file};
+			configJson.files = files;
+			return configJson;
+		}
+
+		[Fact]
+		public void PathsFindFiles()
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig("john/quincy/adams/test.txt");
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Single(foundFiles);
+			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
+		}
+
+		[Fact]
+		public void GlobsFindFiles()
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig("john/quincy/adams/*.txt");
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Equal(2, foundFiles.Count);
+			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Contains(@"C:\john\quincy\adams\test.txt", foundFilesArray);
+			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
+		}
+
+		[Fact]
+		public void GlobsFindFilesRecursively()
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig("john/**/*.txt");
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Equal(6, foundFiles.Count);
+			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Contains(@"C:\john\test.txt", foundFilesArray);
+			Assert.Contains(@"C:\john\doe\test.txt", foundFilesArray);
+			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
+			Assert.DoesNotContain(foundFilesArray, file => file.Contains("jane"));
+		}
+
+		[Fact(Skip = "not implemented")]
+		public void GlobsFindFilesRecursivelyInSpecifiedSubdirs()
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig("john/**/doe/*.txt");
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Equal(3, foundFiles.Count);
+		}
+
+		[Fact(Skip = "not implemented")]
+		public void GlobsFindFilesInSiblingDirs()
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig("john/quincy/*/*.txt");
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Equal(3, foundFiles.Count);
+			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Contains(@"C:\john\quincy\adams\test.txt", foundFilesArray);
+			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
+			Assert.Contains(@"C:\john\quincy\doe\test.txt", foundFilesArray);
+		}
+
+		[Theory]
+		[InlineData("john/*/*.txt")]
+		[InlineData("**/quincy/**/*.txt")]
+		[InlineData("john/**/doe/*.txt")]
+		public void HelpfulErrorsForUnsupportedSyntax(string sourceExpression)
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig(sourceExpression);
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				var e = Assert.Throws<NotImplementedException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles));
+				Assert.Contains("Please submit a pull request", e.Message);
+				Assert.Contains(sourceExpression, e.Message);
+			}
+		}
+
+		[Theory]
+		[InlineData(".", @"jane\doe\test.txt")]
+		[InlineData(@"jane\doe", @"test.txt", Skip = "for followup commit. Ship early; ship often.")] // TODO: implement absolute base path handling
+		public void BasePathExcludedFromKeys(string basePath, string subPath)
+		{
+			var mockFileSystem = SetUpDirectoryStructure();
+			var configJson = SetUpConfig(subPath, basePath);
+			var foundFiles = new Dictionary<string, FileInfo>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+			}
+
+			Assert.Single(foundFiles);
+			Assert.Equal(@"C:\jane\doe\test.txt", foundFiles.Values.First().FullName);
+			Assert.Equal(subPath, foundFiles.Keys.First());
+		}
+	}
+}

--- a/OvercrowdinTests/UpdateCommandTests.cs
+++ b/OvercrowdinTests/UpdateCommandTests.cs
@@ -23,7 +23,7 @@ namespace OvercrowdinTests
 		public async void MissingApiKeyReturnsFailure()
 		{
 			var mockFileSystem = new MockFileSystem();
-			const string inputFileName = "test.json";
+			const string inputFileName = "test.txt";
 			const string apiKeyEnvVar = "NOKEYEXISTS";
 			const string projectId = "testcrowdinproject";
 			_mockConfig.Setup(config => config["api_key_env"]).Returns(apiKeyEnvVar);
@@ -41,7 +41,7 @@ namespace OvercrowdinTests
 		public async void UpdateCommandWithCommandLine()
 		{
 			var mockFileSystem = new MockFileSystem();
-			const string inputFileName = "test.json";
+			const string inputFileName = "test.txt";
 			const string apiKeyEnvVar = "KEYEXISTS";
 			const string projectId = "testcrowdinproject";
 			Environment.SetEnvironmentVariable(apiKeyEnvVar, "fakecrowdinapikey");
@@ -62,18 +62,18 @@ namespace OvercrowdinTests
 		public async void UpdateCommandWithConfigFile()
 		{
 			var mockFileSystem = new MockFileSystem();
-			const string inputFileName = "test.json";
+			const string inputFileName = "test.txt";
 			const string apiKeyEnvVar = "KEYEXISTS";
 			const string projectId = "testcrowdinproject";
 			Environment.SetEnvironmentVariable(apiKeyEnvVar, "fakecrowdinapikey");
-			mockFileSystem.File.WriteAllText("test.json", "{ mock: config }");
+			mockFileSystem.File.WriteAllText(inputFileName, "mock contents");
 			dynamic configJson = new JObject();
 
 			configJson.project_id = projectId;
 			configJson.api_key_env = apiKeyEnvVar;
 			configJson.base_path = ".";
 			dynamic file = new JObject();
-			file.source = "test.json";
+			file.source = inputFileName;
 			var files = new JArray();
 			files.Add(file);
 			configJson.files = files;

--- a/src/Overcrowdin/CommandUtilities.cs
+++ b/src/Overcrowdin/CommandUtilities.cs
@@ -1,16 +1,40 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace Overcrowdin
 {
 	public static class CommandUtilities
 	{
+		private const string UnsupportedSyntaxX =
+			"The specified source syntax is not supported. Please submit a pull request to help us support ";
+
+		public static Dictionary<string, FileInfo> GetFileList(IConfiguration config, IFileOptions opts, IFileSystem fs)
+		{
+			var files = new Dictionary<string, FileInfo>();
+			// handle files specified on the command line
+			if (opts.Files != null && opts.Files.Any())
+			{
+				foreach (var file in opts.Files)
+				{
+					files[file] = new FileInfo(file); // TODO (Hasso) 2019.12: use the full relative path here and elsewhere. Centralize.
+				}
+			}
+			else
+			{
+				GetFilesFromConfiguration(config, fs, files);
+			}
+
+			return files;
+		}
+
 		/// <summary>Read from configuration files section that resembles:
 		/// files : [
 		///  {
-		///    "source" : "resources/en/*.json",
+		///    "source" : "resources/en/**/*.json",
 		///    "translation" : "resources/%two_letters_code%/%original_file_name"
 		///  }
 		/// ]
@@ -21,11 +45,31 @@ namespace Overcrowdin
 			var filesSection = config.GetSection("files");
 			foreach (IConfigurationSection section in filesSection.GetChildren())
 			{
-				var filePattern = section.GetValue<string>("source");
-				var matchedFiles = fs.Directory.GetFiles(fs.Directory.GetCurrentDirectory(), filePattern);
+				var source = section.GetValue<string>("source");
+				var basePath = fs.Directory.GetCurrentDirectory();
+				var basePathLength = basePath.Length;
+				var directory = Path.Combine(basePath, Path.GetDirectoryName(source));
+				var searchOption = SearchOption.TopDirectoryOnly;
+				if (directory.Contains("***"))
+				{
+					throw new NotImplementedException(UnsupportedSyntaxX + source);
+				}
+				if (directory.EndsWith("**"))
+				{
+					// For now, we support recursion only at the end of the directory path. Other options are not worth our effort at this time.
+					directory = Path.GetDirectoryName(directory);
+					searchOption = SearchOption.AllDirectories;
+				}
+				if (directory.Contains('*'))
+				{
+					throw new NotImplementedException(UnsupportedSyntaxX + source);
+				}
+				var filePattern = Path.GetFileName(source);
+				var matchedFiles = fs.Directory.GetFiles(directory, filePattern, searchOption);
 				foreach (var sourceFile in matchedFiles)
 				{
-					files[Path.GetFileName(sourceFile)] = new FileInfo(sourceFile);
+					// two off-by-one errors cancel each other out to cleanly trim the path separator from the key
+					files[sourceFile.Substring(basePathLength)] = new FileInfo(sourceFile);
 				}
 			}
 		}

--- a/src/Overcrowdin/GlobalOptions.cs
+++ b/src/Overcrowdin/GlobalOptions.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using CommandLine;
 
 namespace Overcrowdin

--- a/src/Overcrowdin/IFileOptions.cs
+++ b/src/Overcrowdin/IFileOptions.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Overcrowdin
+{
+	/// <summary>
+	/// Options that apply to every verb
+	/// </summary>
+	public interface IFileOptions
+	{
+		IEnumerable<string> Files { get; set; }
+	}
+}


### PR DESCRIPTION
- find files in recursive subdirectories
- helpful error for unsupported globs
- WIP: use relative paths for files' keys
- clarify some existing unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/overcrowdin/8)
<!-- Reviewable:end -->
