### PR TITLE
Allow export_patterns (translations)

### DIFF
--- a/OvercrowdinTests/CommandUtilitiesTests.cs
+++ b/OvercrowdinTests/CommandUtilitiesTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Text;
+using Crowdin.Api.Typed;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 using Overcrowdin;
@@ -22,7 +22,6 @@ namespace OvercrowdinTests
 			fileSys.Directory.CreateDirectory("john/quincy/doe");
 			fileSys.File.WriteAllText("test.txt", "contents");
 			fileSys.File.WriteAllText("jane/test.txt", "contents");
-			fileSys.File.WriteAllText("jane/doe/test.txt", "contents");
 			fileSys.File.WriteAllText("jane/doe/test.txt", "contents");
 			fileSys.File.WriteAllText("john/test.txt", "contents");
 			fileSys.File.WriteAllText("john/doe/test.txt", "contents");
@@ -52,16 +51,16 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("john/quincy/adams/test.txt");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Single(foundFiles);
-			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
+			Assert.Single(fileParams.Files);
+			Assert.Equal(@"C:\john\quincy\adams\test.txt", fileParams.Files.Values.First().FullName);
 		}
 
 		[Fact]
@@ -69,16 +68,16 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("john/quincy/adams/*.txt");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Equal(2, foundFiles.Count);
-			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Equal(2, fileParams.Files.Count);
+			var foundFilesArray = fileParams.Files.Values.Select(val => val.FullName).ToArray();
 			Assert.Contains(@"C:\john\quincy\adams\test.txt", foundFilesArray);
 			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
 		}
@@ -88,16 +87,16 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("john/**/*.txt");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Equal(6, foundFiles.Count);
-			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Equal(6, fileParams.Files.Count);
+			var foundFilesArray = fileParams.Files.Values.Select(val => val.FullName).ToArray();
 			Assert.Contains(@"C:\john\test.txt", foundFilesArray);
 			Assert.Contains(@"C:\john\doe\test.txt", foundFilesArray);
 			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
@@ -109,15 +108,15 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("john/**/doe/*.txt");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Equal(3, foundFiles.Count);
+			Assert.Equal(3, fileParams.Files.Count);
 		}
 
 		[Fact(Skip = "not implemented")]
@@ -125,16 +124,16 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("john/quincy/*/*.txt");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Equal(3, foundFiles.Count);
-			var foundFilesArray = foundFiles.Values.Select(val => val.FullName).ToArray();
+			Assert.Equal(3, fileParams.Files.Count);
+			var foundFilesArray = fileParams.Files.Values.Select(val => val.FullName).ToArray();
 			Assert.Contains(@"C:\john\quincy\adams\test.txt", foundFilesArray);
 			Assert.Contains(@"C:\john\quincy\adams\allonym.txt", foundFilesArray);
 			Assert.Contains(@"C:\john\quincy\doe\test.txt", foundFilesArray);
@@ -148,12 +147,12 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig(sourceExpression);
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				var e = Assert.Throws<NotImplementedException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles));
+				var e = Assert.Throws<NotImplementedException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams));
 				Assert.Contains("Please submit a pull request", e.Message);
 				Assert.Contains(sourceExpression, e.Message);
 			}
@@ -165,12 +164,12 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig(subPath, basePath);
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				var e = Assert.Throws<NotSupportedException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles));
+				var e = Assert.Throws<NotSupportedException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams));
 				Assert.Contains(subPath, e.Message);
 			}
 		}
@@ -180,15 +179,47 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("C:/jane/*.txt", @"C:\john");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
 				// DNF is helpful enough, and checking earlier is too complicated for such an unexpected error
-				var e = Assert.Throws<DirectoryNotFoundException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles));
+				var e = Assert.Throws<DirectoryNotFoundException>(() => CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams));
 				Assert.Contains(@"C:\john\C:\jane", e.Message);
 			}
+		}
+
+		[Fact]
+		public void TranslationExportPatterns()
+		{
+			const string janePattern = "/l10n/%two_letters_code%/jane_doe/%original_file_name%";
+			const string johnPattern = "/l10n/%two_letters_code%/john/**/%file_name%.%two_letters_code%.%file_extension%";
+			var mockFileSystem = SetUpDirectoryStructure();
+			dynamic configJson = SetUpConfig("/jane/doe/*.txt");
+			var files = configJson.files;
+			files[0].translation = janePattern;
+			dynamic file = new JObject();
+			file.source = "/john/quincy/**/*.txt";
+			file.translation = johnPattern;
+			files.Add(file);
+			var fileParams = new UpdateFileParameters();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
+			}
+
+			Assert.Equal(5, fileParams.Files.Count);
+			Assert.Equal(5, fileParams.ExportPatterns.Count);
+			foreach (var key in fileParams.Files.Keys)
+			{
+				Assert.Contains(key, fileParams.ExportPatterns.Keys);
+			}
+			Assert.Equal(janePattern, fileParams.ExportPatterns["jane/doe/test.txt"]);
+			Assert.Equal(johnPattern, fileParams.ExportPatterns["john/quincy/adams/allonym.txt"]);
+			Assert.Equal(johnPattern, fileParams.ExportPatterns["john/quincy/doe/test.txt"]);
 		}
 
 		[Theory]
@@ -202,17 +233,17 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig(subPath, basePath);
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 			}
 
-			Assert.Single(foundFiles);
-			Assert.Equal(@"C:\jane\doe\test.txt", foundFiles.Values.First().FullName);
-			Assert.Equal(subPath, foundFiles.Keys.First());
+			Assert.Single(fileParams.Files);
+			Assert.Equal(@"C:\jane\doe\test.txt", fileParams.Files.Values.First().FullName);
+			Assert.Equal(subPath, fileParams.Files.Keys.First());
 		}
 
 		[Fact]
@@ -220,7 +251,7 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("/adams/test.txt", "C:/john/quincy");
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
@@ -229,7 +260,7 @@ namespace OvercrowdinTests
 				try
 				{
 					mockFileSystem.Directory.SetCurrentDirectory("C:/jane/doe");
-					CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+					CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 				}
 				finally
 				{
@@ -237,9 +268,9 @@ namespace OvercrowdinTests
 				}
 			}
 
-			Assert.Single(foundFiles);
-			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
-			Assert.Equal("adams/test.txt", foundFiles.Keys.First());
+			Assert.Single(fileParams.Files);
+			Assert.Equal(@"C:\john\quincy\adams\test.txt", fileParams.Files.Values.First().FullName);
+			Assert.Equal("adams/test.txt", fileParams.Files.Keys.First());
 		}
 
 		[Theory]
@@ -249,7 +280,7 @@ namespace OvercrowdinTests
 		{
 			var mockFileSystem = SetUpDirectoryStructure();
 			var configJson = SetUpConfig("/adams/test.txt", relativeBasePath);
-			var foundFiles = new Dictionary<string, FileInfo>();
+			var fileParams = new AddFileParameters();
 
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
@@ -258,7 +289,7 @@ namespace OvercrowdinTests
 				try
 				{
 					mockFileSystem.Directory.SetCurrentDirectory(currentDir);
-					CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, foundFiles);
+					CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParams);
 				}
 				finally
 				{
@@ -266,9 +297,9 @@ namespace OvercrowdinTests
 				}
 			}
 
-			Assert.Single(foundFiles);
-			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
-			Assert.Equal("adams/test.txt", foundFiles.Keys.First());
+			Assert.Single(fileParams.Files);
+			Assert.Equal(@"C:\john\quincy\adams\test.txt", fileParams.Files.Values.First().FullName);
+			Assert.Equal("adams/test.txt", fileParams.Files.Keys.First());
 		}
 	}
 }

--- a/OvercrowdinTests/CommandUtilitiesTests.cs
+++ b/OvercrowdinTests/CommandUtilitiesTests.cs
@@ -192,7 +192,7 @@ namespace OvercrowdinTests
 		}
 
 		[Theory]
-		[InlineData(".", @"jane\doe\test.txt")]
+		[InlineData(".", "jane/doe/test.txt")]
 		[InlineData(@"jane\doe", "test.txt")]
 		[InlineData(@"jane\doe\", "test.txt")]
 		[InlineData(@"jane/doe/", "test.txt")]
@@ -239,7 +239,7 @@ namespace OvercrowdinTests
 
 			Assert.Single(foundFiles);
 			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
-			Assert.Equal(@"adams\test.txt", foundFiles.Keys.First());
+			Assert.Equal("adams/test.txt", foundFiles.Keys.First());
 		}
 
 		[Theory]
@@ -268,7 +268,7 @@ namespace OvercrowdinTests
 
 			Assert.Single(foundFiles);
 			Assert.Equal(@"C:\john\quincy\adams\test.txt", foundFiles.Values.First().FullName);
-			Assert.Equal(@"adams\test.txt", foundFiles.Keys.First());
+			Assert.Equal("adams/test.txt", foundFiles.Keys.First());
 		}
 	}
 }

--- a/src/Overcrowdin/AddCommand.cs
+++ b/src/Overcrowdin/AddCommand.cs
@@ -25,7 +25,8 @@ namespace Overcrowdin
 			var projectId = config["project_identifier"];
 			var projectKey = Environment.GetEnvironmentVariable(config["api_key_env"]);
 			var projectCredentials = new ProjectCredentials { ProjectKey = projectKey };
-			var addFileParams = new AddFileParameters { Files = CommandUtilities.GetFileList(config, opts, fs) };
+			var addFileParams = new AddFileParameters();
+			CommandUtilities.GetFileList(config, opts, fs, addFileParams);
 			Console.WriteLine("Adding {0} files...", addFileParams.Files.Count);
 			var result = await crowdin.AddFile(projectId,
 				projectCredentials, addFileParams);

--- a/src/Overcrowdin/CommandUtilities.cs
+++ b/src/Overcrowdin/CommandUtilities.cs
@@ -84,7 +84,9 @@ namespace Overcrowdin
 				var matchedFiles = fs.Directory.GetFiles(directory, filePattern, searchOption);
 				foreach (var sourceFile in matchedFiles)
 				{
-					files[sourceFile.Substring(basePathLength)] = new FileInfo(sourceFile);
+					// Key is the relative path with Unix directory separators
+					var key = sourceFile.Substring(basePathLength).Replace(Path.DirectorySeparatorChar, '/');
+					files[key] = new FileInfo(sourceFile);
 				}
 			}
 		}

--- a/src/Overcrowdin/CommandUtilities.cs
+++ b/src/Overcrowdin/CommandUtilities.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using Crowdin.Api.Typed;
 using Microsoft.Extensions.Configuration;
 
 namespace Overcrowdin
@@ -12,23 +13,25 @@ namespace Overcrowdin
 		private const string UnsupportedSyntaxX =
 			"The specified source syntax is not supported. Please submit a pull request to help us support ";
 
-		public static Dictionary<string, FileInfo> GetFileList(IConfiguration config, IFileOptions opts, IFileSystem fs)
+		public static void GetFileList(IConfiguration config, IFileOptions opts, IFileSystem fs, FileParameters fileParams)
 		{
-			var files = new Dictionary<string, FileInfo>();
+			if (fileParams.Files == null)
+			{
+				fileParams.Files = new Dictionary<string, FileInfo>();
+			}
+
 			// handle files specified on the command line
 			if (opts.Files != null && opts.Files.Any())
 			{
 				foreach (var file in opts.Files)
 				{
-					files[file] = new FileInfo(file); // TODO (Hasso) 2019.12: use the full relative path here and elsewhere. Centralize.
+					fileParams.Files[file] = new FileInfo(file); // TODO (Hasso) 2019.12: normalize keys: no C:\, Unix dir separators, (filename only?)
 				}
 			}
 			else
 			{
-				GetFilesFromConfiguration(config, fs, files);
+				GetFilesFromConfiguration(config, fs, fileParams);
 			}
-
-			return files;
 		}
 
 		/// <summary>Read from configuration files section that resembles:
@@ -38,10 +41,18 @@ namespace Overcrowdin
 		///    "translation" : "resources/%two_letters_code%/%original_file_name"
 		///  }
 		/// ]
-		/// ENHANCE: put the translation destination into Crowdin
 		/// </summary>
-		public static void GetFilesFromConfiguration(IConfiguration config, IFileSystem fs, Dictionary<string, FileInfo> files)
+		public static void GetFilesFromConfiguration(IConfiguration config, IFileSystem fs, FileParameters fileParams)
 		{
+			if (fileParams.Files == null)
+			{
+				fileParams.Files = new Dictionary<string, FileInfo>();
+			}
+			if (fileParams.ExportPatterns == null)
+			{
+				fileParams.ExportPatterns = new Dictionary<string, string>();
+			}
+
 			var basePath = config.GetValue<string>("base_path");
 			basePath = basePath.Equals(".")
 				? fs.Directory.GetCurrentDirectory()
@@ -58,6 +69,7 @@ namespace Overcrowdin
 			foreach (IConfigurationSection section in filesSection.GetChildren())
 			{
 				var source = section.GetValue<string>("source");
+				var translation = section.GetValue<string>("translation");
 				// A leading directory separator char (permissible in source) causes Path.Combine to interpret the path as rooted,
 				// but the source path is always relative (to base_path), so use join here.
 				var directory = fs.DirectoryInfo.FromDirectoryName(Path.Join(basePath, Path.GetDirectoryName(source))).FullName;
@@ -86,7 +98,8 @@ namespace Overcrowdin
 				{
 					// Key is the relative path with Unix directory separators
 					var key = sourceFile.Substring(basePathLength).Replace(Path.DirectorySeparatorChar, '/');
-					files[key] = new FileInfo(sourceFile);
+					fileParams.Files[key] = new FileInfo(sourceFile);
+					fileParams.ExportPatterns[key] = translation;
 				}
 			}
 		}

--- a/src/Overcrowdin/Overcrowdin.csproj
+++ b/src/Overcrowdin/Overcrowdin.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://github.com/sillsdev/overcrowdin</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sillsdev/overcrowdin</RepositoryUrl>
     <PackageIcon>images/icon.png</PackageIcon>
-    <PackageTags>.NET Core;l10n;localization;cli</PackageTags>
+    <PackageTags>.NET Core;l10n;localisation;localization;cli</PackageTags>
     <PackageReleaseNotes>First version includes support for generating a configuration file from a crowdin project, adding source files to crowdin, updating source files in crowdin and downloading translation zip files from crowdin.</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Overcrowdin/Overcrowdin.csproj
+++ b/src/Overcrowdin/Overcrowdin.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="Crowdin.Api" Version="1.0.1" />
+    <PackageReference Include="Crowdin.Api" Version="1.0.2" />
     <PackageReference Include="GitVersionTask" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />

--- a/src/Overcrowdin/UpdateCommand.cs
+++ b/src/Overcrowdin/UpdateCommand.cs
@@ -30,7 +30,8 @@ namespace Overcrowdin
 			if (!string.IsNullOrEmpty(projectKey))
 			{
 				var projectCredentials = new ProjectCredentials {ProjectKey = projectKey};
-				var updateFileParameters = new UpdateFileParameters { Files = CommandUtilities.GetFileList(config, opts, fileSystem) };
+				var updateFileParameters = new UpdateFileParameters();
+				CommandUtilities.GetFileList(config, opts, fileSystem, updateFileParameters);
 				Console.WriteLine("Updating {0} files...", updateFileParameters.Files.Count);
 				var crowdinResult = await crowdin.UpdateFile(projectId,
 					projectCredentials, updateFileParameters);


### PR DESCRIPTION
- Use Unix path separators in keys (to normalize them)
- Include an export_patterns entry for each files entry (export_patterns are called "translations" in the config file)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/overcrowdin/12)
<!-- Reviewable:end -->
