### PR TITLE
Retry failed downloads

### DIFF
--- a/OvercrowdinTests/AddCommandTests.cs
+++ b/OvercrowdinTests/AddCommandTests.cs
@@ -4,7 +4,6 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Crowdin.Api;
 using Crowdin.Api.Typed;
@@ -32,10 +31,7 @@ namespace OvercrowdinTests
 			_mockClient.Setup(x => x.AddFile(It.IsAny<string>(), It.IsAny<ProjectCredentials>(), It.Is<AddFileParameters>(fp => fp.Files.ContainsKey(inputFileName))))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 				.Verifiable();
-			var gate = new AutoResetEvent(false);
-			var result = await AddCommand.AddFilesToCrowdin(_mockConfig.Object, new AddCommand.Options { Files = new[] { inputFileName } },
-				gate, mockFileSystem);
-			gate.WaitOne();
+			var result = await AddCommand.AddFilesToCrowdin(_mockConfig.Object, new AddCommand.Options { Files = new[] { inputFileName } }, mockFileSystem);
 			_mockClient.Verify();
 			Assert.Equal(0, result);
 		}
@@ -67,9 +63,7 @@ namespace OvercrowdinTests
 				_mockClient.Setup(x => x.AddFile(It.IsAny<string>(), It.IsAny<ProjectCredentials>(), It.Is<AddFileParameters>(fp => fp.Files.ContainsKey(inputFileName))))
 					.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 					.Verifiable();
-				var gate = new AutoResetEvent(false);
-				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}
@@ -96,9 +90,7 @@ namespace OvercrowdinTests
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var configurationBuilder = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				var gate = new AutoResetEvent(false);
-				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}
@@ -140,9 +132,7 @@ namespace OvercrowdinTests
 						It.Is<AddFileParameters>(fp => fp.Files.Count == 2 && fp.ExportPatterns.Count == 2)))
 					.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 					.Verifiable("second batch");
-				var gate = new AutoResetEvent(false);
-				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await AddCommand.AddFilesToCrowdin(configurationBuilder, new AddCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}
@@ -167,10 +157,7 @@ namespace OvercrowdinTests
 			_mockClient.Setup(x => x.CreateFolder(projectId, It.IsAny<ProjectCredentials>(), It.Is<CreateFolderParameters>(fp => fp.Name.StartsWith(pathParts[0]))))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 				.Verifiable("should have created folder");
-			var gate = new AutoResetEvent(false);
-			var result = await AddCommand.AddFilesToCrowdin(_mockConfig.Object, new AddCommand.Options { Files = new[] { inputFileName } },
-				gate, mockFileSystem);
-			gate.WaitOne();
+			var result = await AddCommand.AddFilesToCrowdin(_mockConfig.Object, new AddCommand.Options { Files = new[] { inputFileName } }, mockFileSystem);
 			_mockClient.Verify();
 			Assert.Equal(0, result);
 		}

--- a/OvercrowdinTests/DownloadCommandTests.cs
+++ b/OvercrowdinTests/DownloadCommandTests.cs
@@ -2,7 +2,6 @@
 using System.IO.Abstractions.TestingHelpers;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Crowdin.Api;
 using Crowdin.Api.Typed;
@@ -23,10 +22,7 @@ namespace OvercrowdinTests
 			_mockConfig.Setup(config => config["api_key_env"]).Returns(apiKeyEnvVar);
 			_mockConfig.Setup(config => config["project_identifier"]).Returns(projectId);
 			_mockConfig.Setup(config => config["base_path"]).Returns(".");
-			var gate = new AutoResetEvent(false);
-			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = true, Filename = "done.zip" },
-				gate, mockFileSystem.FileSystem);
-			gate.WaitOne();
+			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = true, Filename = "done.zip" }, mockFileSystem.FileSystem);
 			_mockClient.Verify();
 			Assert.Equal(1, result);
 		}
@@ -51,10 +47,7 @@ namespace OvercrowdinTests
 					It.IsAny<DownloadTranslationParameters>()))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted) {Content = new ByteArrayContent(new byte[] {0x50, 0x4b, 0x03, 0x04})}));
 			mockFileSystem.Directory.CreateDirectory(baseDir);
-			var gate = new AutoResetEvent(false);
-			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = true, Filename = outputFileName },
-				gate, mockFileSystem.FileSystem);
-			gate.WaitOne();
+			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = true, Filename = outputFileName }, mockFileSystem.FileSystem);
 			_mockClient.Verify(x => x.ExportTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<ExportTranslationParameters>()), Times.Exactly(1));
 			_mockClient.Verify(x => x.DownloadTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<DownloadTranslationParameters>()), Times.Exactly(1));
 			Assert.Equal(0, result);
@@ -77,10 +70,7 @@ namespace OvercrowdinTests
 					It.IsAny<DownloadTranslationParameters>()))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new ByteArrayContent(new byte[] { 0x50, 0x4b, 0x03, 0x04 }) }));
 			mockFileSystem.Directory.CreateDirectory(baseDir);
-			var gate = new AutoResetEvent(false);
-			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = false, Filename = outputFileName },
-				gate, mockFileSystem.FileSystem);
-			gate.WaitOne();
+			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, new DownloadCommand.Options { ExportFirst = false, Filename = outputFileName }, mockFileSystem.FileSystem);
 			_mockClient.Verify(x => x.ExportTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<ExportTranslationParameters>()), Times.Never);
 			_mockClient.Verify(x => x.DownloadTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<DownloadTranslationParameters>()), Times.Exactly(1));
 			Assert.Equal(0, result);
@@ -103,9 +93,7 @@ namespace OvercrowdinTests
 			_mockClient.Setup(client => client.DownloadTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<DownloadTranslationParameters>()))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
 			mockFileSystem.Directory.CreateDirectory(baseDir);
-			var gate = new AutoResetEvent(false);
-			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, options, gate, mockFileSystem.FileSystem);
-			gate.WaitOne();
+			var result = await DownloadCommand.DownloadFromCrowdin(_mockConfig.Object, options, mockFileSystem.FileSystem);
 			_mockClient.Verify(x => x.DownloadTranslation(projectId, It.IsAny<ProjectCredentials>(), It.IsAny<DownloadTranslationParameters>()), Times.Exactly(1));
 			Assert.Equal(1, result);
 		}

--- a/OvercrowdinTests/GenerateCommandTests.cs
+++ b/OvercrowdinTests/GenerateCommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using Crowdin.Api;
@@ -22,10 +21,8 @@ namespace OvercrowdinTests
 			Environment.SetEnvironmentVariable("KEYEXISTS", "fakecrowdinapikey");
 			_mockClient.Setup(x => x.GetProjectInfo(It.IsAny<string>(), It.IsAny<ProjectCredentials>()))
 				.Throws(new CrowdinException("No user", 404));
-			var gate = new AutoResetEvent(false);
 			var result = await GenerateCommand.GenerateConfigFromCrowdin(_mockConfig.Object,
-				new GenerateCommand.Options {BasePath = ".", Key = "KEYEXISTS"}, gate, mockFileSystem);
-			gate.WaitOne();
+				new GenerateCommand.Options {BasePath = ".", Key = "KEYEXISTS"}, mockFileSystem);
 			Assert.Equal(1, result);
 		}
 
@@ -33,10 +30,8 @@ namespace OvercrowdinTests
 		public async void NoAPIKeyFails()
 		{
 			var mockFileSystem = new MockFileSystem();
-			var gate = new AutoResetEvent(false);
 			var result = await GenerateCommand.GenerateConfigFromCrowdin(_mockConfig.Object,
-				new GenerateCommand.Options {BasePath = ".", Key = "FAKEAPIKEYENVVARFORTESET"}, gate, mockFileSystem);
-			gate.WaitOne();
+				new GenerateCommand.Options {BasePath = ".", Key = "FAKEAPIKEYENVVARFORTESET"}, mockFileSystem);
 			Assert.Equal(1, result);
 		}
 
@@ -59,12 +54,9 @@ namespace OvercrowdinTests
 			Assert.NotNull(projectInfo); // verify that the test data is good
 			_mockClient.Setup(x => x.GetProjectInfo(It.IsAny<string>(), It.IsAny<ProjectCredentials>()))
 				.Returns(Task.FromResult(projectInfo));
-			var gate = new AutoResetEvent(false);
 			var result = await GenerateCommand.GenerateConfigFromCrowdin(_mockConfig.Object,
 				new GenerateCommand.Options
-					{BasePath = basePath, Key = apiKeyEnvVar, OutputFile = outputFileName, Identifier = projectIdentifier},
-				gate, mockFileSystem);
-			gate.WaitOne();
+					{BasePath = basePath, Key = apiKeyEnvVar, OutputFile = outputFileName, Identifier = projectIdentifier}, mockFileSystem);
 			var mockOutputFile = mockFileSystem.GetFile(outputFileName).TextContents;
 			var contents = JObject.Parse(mockOutputFile);
 			Assert.True(contents.ContainsKey("project_identifier"));
@@ -95,12 +87,9 @@ namespace OvercrowdinTests
 			Assert.NotNull(projectInfo); // verify that the test data is good
 			_mockClient.Setup(x => x.GetProjectInfo(It.IsAny<string>(), It.IsAny<ProjectCredentials>()))
 				.Returns(Task.FromResult(projectInfo));
-			var gate = new AutoResetEvent(false);
 			var result = await GenerateCommand.GenerateConfigFromCrowdin(_mockConfig.Object,
 				new GenerateCommand.Options
-					{BasePath = basePath, Key = apiKeyEnvVar, OutputFile = outputFileName, Identifier = projectIdentifier},
-				gate, mockFileSystem);
-			gate.WaitOne();
+					{BasePath = basePath, Key = apiKeyEnvVar, OutputFile = outputFileName, Identifier = projectIdentifier}, mockFileSystem);
 			var mockOutputFile = mockFileSystem.GetFile(outputFileName).TextContents;
 			var contents = JObject.Parse(mockOutputFile);
 			Assert.True(contents.ContainsKey("project_identifier"));

--- a/OvercrowdinTests/UpdateCommandTests.cs
+++ b/OvercrowdinTests/UpdateCommandTests.cs
@@ -4,7 +4,6 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Crowdin.Api;
 using Crowdin.Api.Typed;
@@ -29,10 +28,7 @@ namespace OvercrowdinTests
 			_mockConfig.Setup(config => config["api_key_env"]).Returns(apiKeyEnvVar);
 			_mockConfig.Setup(config => config["project_identifier"]).Returns(projectId);
 			// No need to set up calls. If the API key is missing, the API call should not be attempted.
-			var gate = new AutoResetEvent(false);
-			var result = await UpdateCommand.UpdateFilesInCrowdin(_mockConfig.Object, new UpdateCommand.Options { Files = new[] { inputFileName } },
-				gate, mockFileSystem.FileSystem);
-			gate.WaitOne();
+			var result = await UpdateCommand.UpdateFilesInCrowdin(_mockConfig.Object, new UpdateCommand.Options { Files = new[] { inputFileName } }, mockFileSystem.FileSystem);
 			_mockClient.Verify();
 			Assert.Equal(1, result);
 		}
@@ -51,10 +47,7 @@ namespace OvercrowdinTests
 			_mockClient.Setup(x => x.UpdateFile(It.IsAny<string>(), It.IsAny<ProjectCredentials>(), It.Is<UpdateFileParameters>(fp => fp.Files.ContainsKey(inputFileName))))
 				.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 				.Verifiable();
-			var gate = new AutoResetEvent(false);
-			var result = await UpdateCommand.UpdateFilesInCrowdin(_mockConfig.Object, new UpdateCommand.Options { Files = new[] { inputFileName } },
-				gate, mockFileSystem);
-			gate.WaitOne();
+			var result = await UpdateCommand.UpdateFilesInCrowdin(_mockConfig.Object, new UpdateCommand.Options { Files = new[] { inputFileName } }, mockFileSystem);
 			_mockClient.Verify();
 			Assert.Equal(0, result);
 		}
@@ -87,9 +80,7 @@ namespace OvercrowdinTests
 				_mockClient.Setup(x => x.UpdateFile(It.IsAny<string>(), It.IsAny<ProjectCredentials>(), It.Is<UpdateFileParameters>(fp => fp.Files.ContainsKey(inputFileName))))
 					.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 					.Verifiable();
-				var gate = new AutoResetEvent(false);
-				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}
@@ -117,9 +108,7 @@ namespace OvercrowdinTests
 			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
 			{
 				var configurationBuilder = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
-				var gate = new AutoResetEvent(false);
-				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}
@@ -162,9 +151,7 @@ namespace OvercrowdinTests
 						It.Is<UpdateFileParameters>(fp => fp.Files.Count == secondBatchSize && fp.ExportPatterns.Count == secondBatchSize)))
 					.Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Accepted)))
 					.Verifiable("second batch");
-				var gate = new AutoResetEvent(false);
-				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), gate, mockFileSystem);
-				gate.WaitOne();
+				var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), mockFileSystem);
 				_mockClient.Verify();
 				Assert.Equal(0, result);
 			}

--- a/src/Overcrowdin/AddCommand.cs
+++ b/src/Overcrowdin/AddCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Crowdin.Api;
@@ -21,79 +20,72 @@ namespace Overcrowdin
 			public IEnumerable<string> Files { get; set; }
 		}
 
-		public static async Task<int> AddFilesToCrowdin(IConfiguration config, Options opts, AutoResetEvent gate, IFileSystem fs)
+		public static async Task<int> AddFilesToCrowdin(IConfiguration config, Options opts, IFileSystem fs)
 		{
-			try
+			var crowdin = CrowdinCommand.GetClient();
+			var projectId = config["project_identifier"];
+			var projectKey = Environment.GetEnvironmentVariable(config["api_key_env"]);
+
+			if (string.IsNullOrEmpty(projectKey))
 			{
-				var crowdin = CrowdinCommand.GetClient();
-				var projectId = config["project_identifier"];
-				var projectKey = Environment.GetEnvironmentVariable(config["api_key_env"]);
-
-				if (string.IsNullOrEmpty(projectKey))
-				{
-					Console.WriteLine($"Environment variable {config["api_key_env"]} did not contain the API Key for your Crowdin project.");
-					return 1;
-				}
-
-				var projectCredentials = new ProjectCredentials {ProjectKey = projectKey};
-				var addFileParamsList = new List<AddFileParameters>();
-				var foldersToCreate = new SortedSet<string>();
-				CommandUtilities.GetFileList(config, opts, fs, addFileParamsList, foldersToCreate);
-
-				if (!addFileParamsList.Any())
-				{
-					Console.WriteLine("No files to add.");
-					return 0;
-				}
-
-				// create folders
-				if (0 != await CreateFolderCommand.CreateFoldersInCrowdin(config, opts, foldersToCreate, fs))
-				{
-					return 1;
-				}
-
-				// Add files to Crowdin
-				Console.WriteLine($"Adding {addFileParamsList.Sum(afp => afp.Files.Count)} files...");
-				HttpResponseMessage result;
-				var i = 0;
-				do
-				{
-					var addFileParams = addFileParamsList[i];
-					result = await crowdin.AddFile(projectId, projectCredentials, addFileParams);
-				} while (++i < addFileParamsList.Count && result.IsSuccessStatusCode);
-
-				// Give results
-				if (result.IsSuccessStatusCode)
-				{
-					Console.WriteLine("Finished Adding files.");
-					if (opts.Verbose)
-					{
-						var info = await result.Content.ReadAsStringAsync();
-						Console.WriteLine(info);
-					}
-				}
-				else
-				{
-					Console.WriteLine("Failure adding files.");
-					// Crowdin adds all files before the problem file. There is no rollback.
-					// Alert the user to the potential state of the project in Crowdin.
-					if (i > 1 || addFileParamsList[0].Files.Count > 1)
-					{
-						Console.WriteLine("Some files may have been added.");
-					}
-
-					if (opts.Verbose)
-					{
-						var error = await result.Content.ReadAsStringAsync();
-						Console.WriteLine(error);
-					}
-				}
-				return result.IsSuccessStatusCode ? 0 : 1;
+				Console.WriteLine($"Environment variable {config["api_key_env"]} did not contain the API Key for your Crowdin project.");
+				return 1;
 			}
-			finally
+
+			var projectCredentials = new ProjectCredentials {ProjectKey = projectKey};
+			var addFileParamsList = new List<AddFileParameters>();
+			var foldersToCreate = new SortedSet<string>();
+			CommandUtilities.GetFileList(config, opts, fs, addFileParamsList, foldersToCreate);
+
+			if (!addFileParamsList.Any())
 			{
-				gate.Set();
+				Console.WriteLine("No files to add.");
+				return 0;
 			}
+
+			// create folders
+			if (0 != await CreateFolderCommand.CreateFoldersInCrowdin(config, opts, foldersToCreate, fs))
+			{
+				return 1;
+			}
+
+			// Add files to Crowdin
+			Console.WriteLine($"Adding {addFileParamsList.Sum(afp => afp.Files.Count)} files...");
+			HttpResponseMessage result;
+			var i = 0;
+			do
+			{
+				var addFileParams = addFileParamsList[i];
+				result = await crowdin.AddFile(projectId, projectCredentials, addFileParams);
+			} while (++i < addFileParamsList.Count && result.IsSuccessStatusCode);
+
+			// Give results
+			if (result.IsSuccessStatusCode)
+			{
+				Console.WriteLine("Finished Adding files.");
+				if (opts.Verbose)
+				{
+					var info = await result.Content.ReadAsStringAsync();
+					Console.WriteLine(info);
+				}
+			}
+			else
+			{
+				Console.WriteLine("Failure adding files.");
+				// Crowdin adds all files before the problem file. There is no rollback.
+				// Alert the user to the potential state of the project in Crowdin.
+				if (i > 1 || addFileParamsList[0].Files.Count > 1)
+				{
+					Console.WriteLine("Some files may have been added.");
+				}
+
+				if (opts.Verbose)
+				{
+					var error = await result.Content.ReadAsStringAsync();
+					Console.WriteLine(error);
+				}
+			}
+			return result.IsSuccessStatusCode ? 0 : 1;
 		}
 	}
 }

--- a/src/Overcrowdin/DownloadCommand.cs
+++ b/src/Overcrowdin/DownloadCommand.cs
@@ -28,7 +28,7 @@ namespace Overcrowdin
 		}
 
 
-		public static async Task<int> DownloadFromCrowdin(IConfiguration config, Options opts, AutoResetEvent gate, IFileSystem fs)
+		public static async Task<int> DownloadFromCrowdin(IConfiguration config, Options opts, IFileSystem fs)
 		{
 			var crowdin = CrowdinCommand.GetClient();
 
@@ -98,7 +98,6 @@ namespace Overcrowdin
 			{
 				Console.WriteLine("{0} did not contain the API Key for your Crowdin project.", config["api_key_env"]);
 			}
-			gate.Set();
 			return status;
 		}
 	}

--- a/src/Overcrowdin/GenerateCommand.cs
+++ b/src/Overcrowdin/GenerateCommand.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO.Abstractions;
-using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Crowdin.Api;
@@ -15,7 +14,7 @@ namespace Overcrowdin
 	/// </summary>
 	public class GenerateCommand
 	{
-		public static async Task<int> GenerateConfigFromCrowdin(IConfiguration config, Options opts, AutoResetEvent gate, IFileSystem fs)
+		public static async Task<int> GenerateConfigFromCrowdin(IConfiguration config, Options opts, IFileSystem fs)
 		{
 			var success = 1;
 			var key = Environment.GetEnvironmentVariable(opts.Key);
@@ -50,7 +49,6 @@ namespace Overcrowdin
 				Console.WriteLine("{0} did not contain the API Key for your Crowdin project.", opts.Key);
 			}
 
-			gate.Set();
 			return success;
 		}
 

--- a/src/Overcrowdin/Program.cs
+++ b/src/Overcrowdin/Program.cs
@@ -31,19 +31,23 @@ namespace Overcrowdin
 			var parseResult = Parser.Default.ParseArguments<GenerateCommand.Options, UpdateCommand.Options, AddCommand.Options, DownloadCommand.Options>(args)
 				.WithParsed<GenerateCommand.Options>(async opts =>
 				{
-					result = await GenerateCommand.GenerateConfigFromCrowdin(config, opts, Gate, fileSystem);
+					result = await GenerateCommand.GenerateConfigFromCrowdin(config, opts, fileSystem);
+					Gate.Set();
 				})
 				.WithParsed<UpdateCommand.Options>(async opts =>
 				{
-					result = await UpdateCommand.UpdateFilesInCrowdin(config, opts, Gate, fileSystem);
+					result = await UpdateCommand.UpdateFilesInCrowdin(config, opts, fileSystem);
+					Gate.Set();
 				})
 				.WithParsed<AddCommand.Options>(async opts =>
 				{
-					result = await AddCommand.AddFilesToCrowdin(config, opts, Gate, fileSystem);
+					result = await AddCommand.AddFilesToCrowdin(config, opts, fileSystem);
+					Gate.Set();
 				})
 				.WithParsed<DownloadCommand.Options>(async opts =>
 				{
-					result = await DownloadCommand.DownloadFromCrowdin(config, opts, Gate, fileSystem);
+					result = await DownloadCommand.DownloadFromCrowdin(config, opts, fileSystem);
+					Gate.Set();
 				})
 				.WithNotParsed(errs =>
 				{

--- a/src/Overcrowdin/UpdateCommand.cs
+++ b/src/Overcrowdin/UpdateCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Crowdin.Api;
@@ -22,72 +21,65 @@ namespace Overcrowdin
 			// TODO: Add option for update approval -- default to Update_as_unapproved
 		}
 
-		public static async Task<int> UpdateFilesInCrowdin(IConfiguration config, Options opts, AutoResetEvent gate, IFileSystem fileSystem)
+		public static async Task<int> UpdateFilesInCrowdin(IConfiguration config, Options opts, IFileSystem fileSystem)
 		{
-			try
+			var crowdin = CrowdinCommand.GetClient();
+
+			var projectId = config["project_identifier"];
+			var projectKey = Environment.GetEnvironmentVariable(config["api_key_env"]);
+			if (string.IsNullOrEmpty(projectKey))
 			{
-				var crowdin = CrowdinCommand.GetClient();
-
-				var projectId = config["project_identifier"];
-				var projectKey = Environment.GetEnvironmentVariable(config["api_key_env"]);
-				if (string.IsNullOrEmpty(projectKey))
-				{
-					Console.WriteLine($"Environment variable {config["api_key_env"]} did not contain the API Key for your Crowdin project.");
-					return 1;
-				}
-
-				var projectCredentials = new ProjectCredentials {ProjectKey = projectKey};
-				var updateFileParametersList = new List<UpdateFileParameters>();
-				CommandUtilities.GetFileList(config, opts, fileSystem, updateFileParametersList, new SortedSet<string>());
-
-				if (!updateFileParametersList.Any())
-				{
-					Console.WriteLine("No files to add.");
-					return 0;
-				}
-
-
-				Console.WriteLine($"Updating {updateFileParametersList.Sum(ufp => ufp.Files.Count)} files...");
-				HttpResponseMessage crowdinResult;
-				var i = 0;
-				do
-				{
-					var updateFileParameters = updateFileParametersList[i];
-					crowdinResult = await crowdin.UpdateFile(projectId, projectCredentials, updateFileParameters);
-				} while (++i < updateFileParametersList.Count && crowdinResult.IsSuccessStatusCode);
-
-				// Give results
-				if (crowdinResult.IsSuccessStatusCode)
-				{
-					Console.WriteLine("Finished Updating files.");
-					if (opts.Verbose)
-					{
-						var info = await crowdinResult.Content.ReadAsStringAsync();
-						Console.WriteLine(info);
-					}
-				}
-				else
-				{
-					Console.WriteLine("Failure updating files.");
-					// A problem file does not cause Crowdin to roll back a batch. Alert the user if some files may have been updated.
-					if (i > 1 || updateFileParametersList[0].Files.Count > 1)
-					{
-						Console.WriteLine("Some files may have been updated.");
-					}
-
-					if (opts.Verbose)
-					{
-						var error = await crowdinResult.Content.ReadAsStringAsync();
-						Console.WriteLine(error);
-					}
-				}
-
-				return crowdinResult.IsSuccessStatusCode ? 0 : 1;
+				Console.WriteLine($"Environment variable {config["api_key_env"]} did not contain the API Key for your Crowdin project.");
+				return 1;
 			}
-			finally
+
+			var projectCredentials = new ProjectCredentials {ProjectKey = projectKey};
+			var updateFileParametersList = new List<UpdateFileParameters>();
+			CommandUtilities.GetFileList(config, opts, fileSystem, updateFileParametersList, new SortedSet<string>());
+
+			if (!updateFileParametersList.Any())
 			{
-				gate.Set();
+				Console.WriteLine("No files to add.");
+				return 0;
 			}
+
+
+			Console.WriteLine($"Updating {updateFileParametersList.Sum(ufp => ufp.Files.Count)} files...");
+			HttpResponseMessage crowdinResult;
+			var i = 0;
+			do
+			{
+				var updateFileParameters = updateFileParametersList[i];
+				crowdinResult = await crowdin.UpdateFile(projectId, projectCredentials, updateFileParameters);
+			} while (++i < updateFileParametersList.Count && crowdinResult.IsSuccessStatusCode);
+
+			// Give results
+			if (crowdinResult.IsSuccessStatusCode)
+			{
+				Console.WriteLine("Finished Updating files.");
+				if (opts.Verbose)
+				{
+					var info = await crowdinResult.Content.ReadAsStringAsync();
+					Console.WriteLine(info);
+				}
+			}
+			else
+			{
+				Console.WriteLine("Failure updating files.");
+				// A problem file does not cause Crowdin to roll back a batch. Alert the user if some files may have been updated.
+				if (i > 1 || updateFileParametersList[0].Files.Count > 1)
+				{
+					Console.WriteLine("Some files may have been updated.");
+				}
+
+				if (opts.Verbose)
+				{
+					var error = await crowdinResult.Content.ReadAsStringAsync();
+					Console.WriteLine(error);
+				}
+			}
+
+			return crowdinResult.IsSuccessStatusCode ? 0 : 1;
 		}
 	}
 }


### PR DESCRIPTION
* Retry failed downloads the specified number of times (option -r) at 4-minute intervals
* Failed exports, or attempting to download translations that do not seem to have been exported, still results in immediate failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/overcrowdin/32)
<!-- Reviewable:end -->
