### PR TITLE
fix: handle empty xml updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ ClientBin/
 *.dbmdl
 *.dbproj.schemaview
 *.jfm
+*.orig
 *.pfx
 *.publishsettings
 node_modules/

--- a/OvercrowdinTests/CommandUtilitiesTests.cs
+++ b/OvercrowdinTests/CommandUtilitiesTests.cs
@@ -493,5 +493,28 @@ namespace OvercrowdinTests
 			Assert.Single(fileParams.FilesToExportPatterns);
 			Assert.Equal(fileNamePassesFilter, fileParams.FilesToExportPatterns.Keys.First());
 		}
+
+		[Fact]
+		public void XmlTypeFiltersRegardlessOfExtension()
+		{
+			var mockFileSystem = new MockFileSystem();
+			const string xmlAsTxt = "strings/string.txt";
+			mockFileSystem.AddFile(xmlAsTxt, new MockFileData(XmlFilterTests.XmlOpenTag + XmlFilterTests.XmlGroupCorrect + XmlFilterTests.XmlCloseTag));
+			dynamic configJson = SetUpConfig(xmlAsTxt);
+			var file = configJson.files[0];
+			file.type = "xml";
+			file.translatable_elements = new JArray { XmlFilterTests.XpathToTranslatableElements };
+			var fileParamsList = new List<AddFileParameters>();
+
+			using (var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString())))
+			{
+				var config = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+				CommandUtilities.GetFilesFromConfiguration(config, mockFileSystem, fileParamsList, new SortedSet<string>());
+			}
+
+			Assert.Single(fileParamsList);
+			Assert.Single(fileParamsList[0].FilesToExportPatterns);
+			Assert.Equal(xmlAsTxt.Replace('\\', '/'), fileParamsList[0].FilesToExportPatterns.Keys.First());
+		}
 	}
 }

--- a/OvercrowdinTests/CommandUtilitiesTests.cs
+++ b/OvercrowdinTests/CommandUtilitiesTests.cs
@@ -500,7 +500,8 @@ namespace OvercrowdinTests
 			var mockFileSystem = new MockFileSystem();
 			const string xmlAsTxt = "strings/string.txt";
 			mockFileSystem.AddFile(xmlAsTxt, new MockFileData(XmlFilterTests.XmlOpenTag + XmlFilterTests.XmlGroupCorrect + XmlFilterTests.XmlCloseTag));
-			dynamic configJson = SetUpConfig(xmlAsTxt);
+			mockFileSystem.AddFile("strings/no-string.txt", new MockFileData(XmlFilterTests.XmlOpenTag + XmlFilterTests.XmlCloseTag));
+			dynamic configJson = SetUpConfig("strings/*.txt");
 			var file = configJson.files[0];
 			file.type = "xml";
 			file.translatable_elements = new JArray { XmlFilterTests.XpathToTranslatableElements };

--- a/OvercrowdinTests/UpdateCommandTests.cs
+++ b/OvercrowdinTests/UpdateCommandTests.cs
@@ -102,8 +102,6 @@ namespace OvercrowdinTests
 			using var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString()));
 			var configurationBuilder = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
 
-			_mockHttpClient.Expect("https://api.crowdin.com/api/v2/projects?limit=25&offset=0&hasManagerAccess=0").Respond(
-				"application/json", $"{{'data':[{{'data': {{'id': {TestProjectId},'identifier': '{TestProjectName}'}}}}]}}");
 			_mockHttpClient.Expect("https://api.crowdin.com/api/v2/projects?limit=500&offset=0&hasManagerAccess=0").Respond(
 				"application/json", $"{{'data':[{{'data': {{'id': {TestProjectId},'identifier': '{TestProjectName}'}}}}]}}");
 			_mockHttpClient.Expect($"https://api.crowdin.com/api/v2/projects/{TestProjectId}/files?limit=500&offset=0&recursion=1").Respond(

--- a/OvercrowdinTests/UpdateCommandTests.cs
+++ b/OvercrowdinTests/UpdateCommandTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -82,6 +84,38 @@ namespace OvercrowdinTests
 			var configurationBuilder = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
 			//SUT
 			var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), mockFileSystem, MockApiFactory);
+			Assert.Equal(0, result);
+			_mockHttpClient.VerifyNoOutstandingExpectation();
+		}
+
+		[Fact]
+		public async Task UpdateRemovesPreviouslyUploadedEmptyXml()
+		{
+			var mockFileSystem = new MockFileSystem();
+			const string xmlFileName = "filterFail.xml";
+			mockFileSystem.File.WriteAllText(xmlFileName, XmlFilterTests.XmlOpenTag + XmlFilterTests.XmlCloseTag);
+			Environment.SetEnvironmentVariable(TestApiKeyEnv, "fakecrowdinapikey");
+			dynamic configJson = SetUpConfig(xmlFileName);
+			configJson.files[0].translatable_elements = new JArray { XmlFilterTests.XpathToTranslatableElements };
+
+			using var memStream = new MemoryStream(Encoding.UTF8.GetBytes(configJson.ToString()));
+			var configurationBuilder = new ConfigurationBuilder().AddNewtonsoftJsonStream(memStream).Build();
+
+			_mockHttpClient.Expect("https://api.crowdin.com/api/v2/projects?limit=25&offset=0&hasManagerAccess=0").Respond(
+				"application/json", $"{{'data':[{{'data': {{'id': {TestProjectId},'identifier': '{TestProjectName}'}}}}]}}");
+			_mockHttpClient.Expect("https://api.crowdin.com/api/v2/projects?limit=500&offset=0&hasManagerAccess=0").Respond(
+				"application/json", $"{{'data':[{{'data': {{'id': {TestProjectId},'identifier': '{TestProjectName}'}}}}]}}");
+			_mockHttpClient.Expect($"https://api.crowdin.com/api/v2/projects/{TestProjectId}/files?limit=500&offset=0&recursion=1").Respond(
+				"application/json", "{'data':[{'data': {'id': 123, 'name': 'filterFail.xml', 'path': 'filterFail.xml', 'branchId': null, 'directoryId': 0}}]}");
+			_mockHttpClient.Expect($"https://api.crowdin.com/api/v2/projects/{TestProjectId}/directories?limit=500&offset=0&recursion=1").Respond(
+				"application/json", "{'data':[{'data': {}}]}");
+			_mockHttpClient.Expect("https://api.crowdin.com/api/v2/storages?limit=500&offset=0").Respond(
+				"application/json", "{'data':[]}");
+			_mockHttpClient.Expect(HttpMethod.Delete, $"https://api.crowdin.com/api/v2/projects/{TestProjectId}/files/123")
+				.Respond(HttpStatusCode.NoContent, "application/json", "{}");
+
+			var result = await UpdateCommand.UpdateFilesInCrowdin(configurationBuilder, new UpdateCommand.Options(), mockFileSystem, MockApiFactory);
+
 			Assert.Equal(0, result);
 			_mockHttpClient.VerifyNoOutstandingExpectation();
 		}

--- a/OvercrowdinTests/UpdateCommandTests.cs
+++ b/OvercrowdinTests/UpdateCommandTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
 using Overcrowdin;
 using RichardSzalay.MockHttp;
 using System;

--- a/OvercrowdinTests/XmlFilterTests.cs
+++ b/OvercrowdinTests/XmlFilterTests.cs
@@ -23,11 +23,11 @@ namespace OvercrowdinTests
 		}
 
 		[Theory]
-		[InlineData("Wrong Attribute", XmlGroupWithWrongAttribute)]
 		[InlineData("Wrong Element", XmlGroupWithWrongElement)]
-		[InlineData("No Attribute", XmlGroupWithoutAttribute)]
+		[InlineData("Wrong Attribute", XmlGroupWithWrongAttribute)]
 		[InlineData("Empty Attribute Value", XmlGroupWithEmptyAttribute)]
 		[InlineData("Empty Element Text", XmlGroupWithEmptyElement)]
+		[InlineData("No Attribute", XmlGroupWithoutAttribute)]
 		[InlineData("Empty File (almost)", "")]
 		public static void ExcludesWrongItems(string message, string xmlGroup)
 		{

--- a/OvercrowdinTests/XmlFilterTests.cs
+++ b/OvercrowdinTests/XmlFilterTests.cs
@@ -26,6 +26,8 @@ namespace OvercrowdinTests
 		[InlineData("Wrong Attribute", XmlGroupWithWrongAttribute)]
 		[InlineData("Wrong Element", XmlGroupWithWrongElement)]
 		[InlineData("No Attribute", XmlGroupWithoutAttribute)]
+		[InlineData("Empty Attribute Value", XmlGroupWithEmptyAttribute)]
+		[InlineData("Empty Element Text", XmlGroupWithEmptyElement)]
 		[InlineData("Empty File (almost)", "")]
 		public static void ExcludesWrongItems(string message, string xmlGroup)
 		{
@@ -58,6 +60,14 @@ namespace OvercrowdinTests
 		internal const string XmlGroupWithWrongAttribute = @"
   <group id='TopGroupWrongAtt'>
     <string wrong='No Records'/>
+  </group>";
+		internal const string XmlGroupWithEmptyAttribute = @"
+  <group id='TopGroupEmptyAtt'>
+    <string txt=''/>
+  </group>";
+		internal const string XmlGroupWithEmptyElement = @"
+  <group id='TopGroupEmptyElt'>
+    <string txt=''>   </string>
   </group>";
 		internal const string XmlGroupWithoutAttribute = @"
   <group id='TopGroupWithoutAtt'>

--- a/src/Overcrowdin/CommandUtilities.cs
+++ b/src/Overcrowdin/CommandUtilities.cs
@@ -34,7 +34,7 @@ namespace Overcrowdin
 		}
 
 		public static void GetFileList<T>(IConfiguration config, IFileOptions opts, IFileSystem fs,
-			List<T> fileParamsList, SortedSet<string> folders) where T : FileParameters, new()
+			List<T> fileParamsList, SortedSet<string> folders, ICollection<string> nonLocalizableFiles = null) where T : FileParameters, new()
 		{
 			// handle files specified on the command line
 			if (opts.Files != null && opts.Files.Any())
@@ -56,7 +56,7 @@ namespace Overcrowdin
 			}
 			else
 			{
-				GetFilesFromConfiguration(config, fs, fileParamsList, folders);
+				GetFilesFromConfiguration(config, fs, fileParamsList, folders, nonLocalizableFiles);
 			}
 
 			AddParentFolders(folders);
@@ -71,7 +71,7 @@ namespace Overcrowdin
 		/// ]
 		/// </summary>
 		public static void GetFilesFromConfiguration<T>(IConfiguration config, IFileSystem fs,
-			List<T> fileParamsList, SortedSet<string> folders) where T : FileParameters, new()
+			List<T> fileParamsList, SortedSet<string> folders, ICollection<string> nonLocalizableFiles = null) where T : FileParameters, new()
 		{
 			var basePath = config.GetValue<string>("base_path");
 			basePath = basePath.Equals(".")
@@ -100,6 +100,7 @@ namespace Overcrowdin
 				{
 					FilesToExportPatterns = new Dictionary<string, string>()
 				};
+				var fileType = section.GetValue<string>("type");
 				var translatableElements = section.GetSection("translatable_elements").GetChildren().Select(te => te.Get<string>()).ToList();
 				if (fileParams is AddFileParameters addFileParams)
 				{
@@ -134,7 +135,7 @@ namespace Overcrowdin
 				var matches = matcher.Execute(basePathInfoWrapper);
 				foreach (var sourceFile in matches.Files.Select(match => match.Path)
 					// REVIEW (Hasso) 2025.11: If a file is modified so that it no longer has translatable elements, this filter will leave the old version in Crowdin on Update.
-					.Where(f => ContentFilter.IsLocalizable(fs, f, translatableElements)))
+					.Where(f => ContentFilter.IsLocalizable(fs, f, translatableElements, fileType)))
 				{
 					// Key is the relative path with Unix directory separators
 					var key = sourceFile.Replace(Path.DirectorySeparatorChar, '/');
@@ -144,6 +145,15 @@ namespace Overcrowdin
 					if (!string.IsNullOrEmpty(dir))
 					{
 						folders.Add(dir);
+					}
+				}
+				// Capture non-localizable files so Update can remove them from Crowdin.
+				if (nonLocalizableFiles != null)
+				{
+					foreach (var sourceFile in matches.Files.Select(match => match.Path)
+								.Where(f => !ContentFilter.IsLocalizable(fs, f, translatableElements, fileType)))
+					{
+						nonLocalizableFiles.Add(sourceFile.Replace(Path.DirectorySeparatorChar, '/'));
 					}
 				}
 				if (fileParams.FilesToExportPatterns.Any())

--- a/src/Overcrowdin/ContentFiltering/ContentFilter.cs
+++ b/src/Overcrowdin/ContentFiltering/ContentFilter.cs
@@ -22,7 +22,7 @@ namespace Overcrowdin.ContentFiltering
 		/// </summary>
 		public static bool IsLocalizable(IFileSystem fs, string path, params object[] args)
 		{
-			var filter = Filters.FirstOrDefault(f => f.CanVerify(path));
+			var filter = Filters.FirstOrDefault(f => f.CanVerify(path, args));
 			if (filter == null)
 			{
 				return true; // this file type is not filtered; all files of this type are localizable

--- a/src/Overcrowdin/ContentFiltering/ContentFilterBase.cs
+++ b/src/Overcrowdin/ContentFiltering/ContentFilterBase.cs
@@ -9,7 +9,7 @@ namespace Overcrowdin.ContentFiltering
 
 		public abstract bool IsLocalizable(IFileSystem fs, string path, params object[] args);
 
-		public virtual bool CanVerify(string path)
+		public virtual bool CanVerify(string path, params object[] args)
 		{
 			return FileExtension.Equals(Path.GetExtension(path));
 		}

--- a/src/Overcrowdin/ContentFiltering/XmlFilter.cs
+++ b/src/Overcrowdin/ContentFiltering/XmlFilter.cs
@@ -54,8 +54,18 @@ namespace Overcrowdin.ContentFiltering
 			{
 				switch (node)
 				{
-					case XElement element when !string.IsNullOrWhiteSpace(element.Value):
-						return true;
+					case XElement element:
+						// Check element's text content
+						if (!string.IsNullOrWhiteSpace(element.Value))
+						{
+							return true;
+						}
+						// Check element's attributes for non-empty values
+						if (element.Attributes().Any(attr => !string.IsNullOrWhiteSpace(attr.Value)))
+						{
+							return true;
+						}
+						break;
 					case XAttribute attribute when !string.IsNullOrWhiteSpace(attribute.Value):
 						return true;
 				}

--- a/src/Overcrowdin/ContentFiltering/XmlFilter.cs
+++ b/src/Overcrowdin/ContentFiltering/XmlFilter.cs
@@ -54,18 +54,13 @@ namespace Overcrowdin.ContentFiltering
 			{
 				switch (node)
 				{
-					case XElement element:
-						// Check element's text content
-						if (!string.IsNullOrWhiteSpace(element.Value))
-						{
-							return true;
-						}
-						// Check element's attributes for non-empty values
-						if (element.Attributes().Any(attr => !string.IsNullOrWhiteSpace(attr.Value)))
-						{
-							return true;
-						}
-						break;
+					// Crowdin interprets XPath differently than .NET's System.Xml.XPath. For example,
+					//  * In .NET, //elt[@att] selects all <elt> elements with an att attribute, but Crowdin will select the value of the att attribute,
+					//    so <elt att="this can be translated">this cannot</elt>.
+					//  * In .NET, //elt/@att selects the value of the att attribute, but Crowdin will select any attribute of an <elt> element,
+					//    so <elt att="this can be translated" other="so can this"/>.
+					// To account for this, we check both the value of the node and the values of its attributes (this is easier than trying to parse the XPath ourselves).
+					case XElement element when (!string.IsNullOrWhiteSpace(element.Value) || element.Attributes().Any(attr => !string.IsNullOrWhiteSpace(attr.Value))):
 					case XAttribute attribute when !string.IsNullOrWhiteSpace(attribute.Value):
 						return true;
 				}

--- a/src/Overcrowdin/ContentFiltering/XmlFilter.cs
+++ b/src/Overcrowdin/ContentFiltering/XmlFilter.cs
@@ -1,10 +1,9 @@
+using System;
 using System.Collections.Generic;
-using System.Collections;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
-using System;
 
 namespace Overcrowdin.ContentFiltering
 {
@@ -45,7 +44,7 @@ namespace Overcrowdin.ContentFiltering
 		private static bool HasContent(XNode doc, string xpath)
 		{
 			var evaluated = doc.XPathEvaluate(xpath);
-			if (evaluated is not IEnumerable enumerable)
+			if (!(evaluated is IEnumerable enumerable))
 			{
 				return false;
 			}

--- a/src/Overcrowdin/ContentFiltering/XmlFilter.cs
+++ b/src/Overcrowdin/ContentFiltering/XmlFilter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;

--- a/src/Overcrowdin/CrowdinHelperBase.cs
+++ b/src/Overcrowdin/CrowdinHelperBase.cs
@@ -140,6 +140,26 @@ namespace Overcrowdin
 				await _client.Storage.DeleteStorage(s.Id);
 		}
 
+		protected async Task<int> DeleteFilesInternal(IEnumerable<string> filePaths)
+		{
+			var deletedCount = 0;
+			foreach (var path in filePaths)
+			{
+				var normalizedPath = path.Replace(Path.DirectorySeparatorChar, '/');
+				var existing = _existingFiles.FirstOrDefault(f =>
+					string.Equals(f.Path, normalizedPath, StringComparison.OrdinalIgnoreCase));
+				if (existing == null)
+				{
+					continue;
+				}
+
+				await _fileExecutor.DeleteFile(_project.Id, existing.Id);
+				deletedCount++;
+			}
+
+			return deletedCount;
+		}
+
 		/// <summary>
 		/// Helper method to get the full count of items back from a call to the Crowdin API (which has a limit of 500 per call)
 		/// </summary>

--- a/src/Overcrowdin/CrowdinUploadHelper.cs
+++ b/src/Overcrowdin/CrowdinUploadHelper.cs
@@ -48,17 +48,6 @@ namespace Overcrowdin
 		{
 			return await DeleteFilesInternal(filePaths);
 		}
-
-		[Obsolete]
-		public async Task<int> CleanupExtraneousFiles()
-		{
-			// Only delete files if there were no errors since errors could cause the list-of-files-to-be-deleted
-			// to contain files that just failed to upload.
-			if (_existingFiles.Count == 0 || FileErrorCount > 0)
-				return 0;
-
-			return await CleanUpExtraneousFilesInternal();
-		}
 		#endregion
 
 		#region Overrides of CrowdinHelperBase

--- a/src/Overcrowdin/CrowdinUploadHelper.cs
+++ b/src/Overcrowdin/CrowdinUploadHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Crowdin.Api.SourceFiles;
@@ -41,6 +42,11 @@ namespace Overcrowdin
 				Console.Error.WriteLine("    " + (e.InnerException != null ? e.InnerException.Message : e.Message));
 				FileErrorCount++;
 			}
+		}
+
+		public async Task<int> DeleteFiles(IEnumerable<string> filePaths)
+		{
+			return await DeleteFilesInternal(filePaths);
 		}
 
 		[Obsolete]

--- a/src/Overcrowdin/UpdateCommand.cs
+++ b/src/Overcrowdin/UpdateCommand.cs
@@ -39,16 +39,19 @@ namespace Overcrowdin
 			}
 			var uploadHelper = await CrowdinUploadHelper.Create(credentials, fileSystem, apiFactory);
 
-			Console.WriteLine($"Updating {updateFileParametersList.Sum(ufp => ufp.FilesToExportPatterns.Count)} files...");
-			var i = 0;
-			do
+			if (updateFileParametersList.Any())
 			{
-				var updateFileParameters = updateFileParametersList[i];
-				foreach (var file in updateFileParameters.FilesToExportPatterns.Keys)
+				Console.WriteLine($"Updating {updateFileParametersList.Sum(ufp => ufp.FilesToExportPatterns.Count)} files...");
+				var i = 0;
+				do
 				{
-					await uploadHelper.UploadFile(fileSystem.File.ReadAllText(file), file, updateFileParameters);
-				}
-			} while (++i < updateFileParametersList.Count);
+					var updateFileParameters = updateFileParametersList[i];
+					foreach (var file in updateFileParameters.FilesToExportPatterns.Keys)
+					{
+						await uploadHelper.UploadFile(fileSystem.File.ReadAllText(file), file, updateFileParameters);
+					}
+				} while (++i < updateFileParametersList.Count);
+			}
 
 			if (nonLocalizableFiles.Any())
 			{
@@ -70,17 +73,7 @@ namespace Overcrowdin
 			}
 			else
 			{
-				Console.WriteLine("A failure occurred while updating the following:\n");
-				foreach (var f in updateFileParametersList[i - 1].FilesToExportPatterns)
-				{
-					Console.WriteLine("  " + f.Key);
-				}
-
-				// A problem file does not cause Crowdin to roll back a batch. Alert the user if some files may have been updated.
-				if (i > 1 || updateFileParametersList[0].FilesToExportPatterns.Count > 1)
-				{
-					Console.WriteLine("Some files may have been updated.");
-				}
+				Console.WriteLine("An error occurred while updating files. Some files may still have been updated.");
 			}
 
 			return uploadHelper.FileErrorCount;


### PR DESCRIPTION
## Summary
- ensure XML filtering checks for actual content and applies when type is set to xml even without .xml extension
- during update, delete previously uploaded files that are now non-localizable so Crowdin doesn’t retain empty XML

## Rationale
Issue #34 requested filtering empty XML uploads and handling the remaining edge case where updated files lose translatable content.

## Changes
- XmlFilter now treats XPath matches with blank elements/attributes as non-localizable and honors config type=xml
- Collect non-localizable matches during update and delete corresponding existing Crowdin files
- Added regression tests for XML content checks, type-based filtering, and update-time deletion

## Test Plan
- Not run (per request)

Fixes #34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/overcrowdin/67)
<!-- Reviewable:end -->
